### PR TITLE
Add missing functions part of refactor - Informix

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -13,6 +13,81 @@ var async = require('async');
 var debug = require('debug')('loopback:connector:informix');
 
 module.exports = function(Informix) {
+
+  Informix.prototype.getAddModifyColumns = function(model, fields) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{getAddModifyColumns()}} is ' +
+      'not currently supported.'));
+    });
+  };
+
+  Informix.prototype.getDropColumns = function(model, fields) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{getDropColumns()}} is not currently supported.'));
+    });
+  };
+
+  Informix.prototype.getColumnsToDrop = function(model, fields) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{getColumnsToDrop()}} is not ' +
+      'currently supported.'));
+    });
+  };
+
+  Informix.prototype.searchForPropertyInActual =
+  function(model, propName, actualFields) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{searchForPropertyInActual()}} is ' +
+      'not currently supported.'));
+    });
+  };
+
+  Informix.prototype.addPropertyToActual = function(model, propName) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{addPropertyToActual()}} is ' +
+      'not currently supported.'));
+    });
+  };
+
+  Informix.prototype.columnDataType = function(model, property) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{columnDataType()}} is not currently supported.'));
+    });
+  };
+
+  Informix.prototype.buildColumnType = function(property) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{buildColumnType()}} is not currently supported.'));
+    });
+  };
+
+  Informix.prototype.propertyHasNotBeenDeleted = function(model, propName) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{propertyHasNotBeenDeleted()}} is ' +
+      'not currently supported.'));
+    });
+  };
+
+  Informix.prototype.applySqlChanges =
+  function(model, pendingChanges, cb) {
+    process.nextTick(function() {
+      return cb(Error(g.f('{{applySqlChanges()}} is not ' +
+      'currently supported.')));
+    });
+  };
+
+  Informix.prototype.showFields = function(model, cb) {
+    process.nextTick(function() {
+      return cb(Error(g.f('{{showFields()}} is not currently supported.')));
+    });
+  };
+
+  Informix.prototype.showIndexes = function(model, cb) {
+    process.nextTick(function() {
+      return cb(Error(g.f('{{showIndexes()}} is not currently supported.')));
+    });
+  };
+
   /*
    * Perform autoupdate for the given models
    * @param {String[]} [models] A model name or an array of model names.


### PR DESCRIPTION
@qpresley PTAL

These are the functions that were refactored as a whole in the loopback base connector and ibmdb connector, and it will be overridden by the new definition **if** they are called for this connector.