### PR TITLE
Add save and updateOrCreate function

### DIFF
--- a/lib/informix.js
+++ b/lib/informix.js
@@ -532,12 +532,6 @@ Informix.prototype.applyPagination = function(model, stmt, filter) {
   return (stmt + limitClause);
 };
 
-Informix.prototype.buildReplace = function(model, where, data, options) {
-  process.nextTick(function() {
-    throw Error(g.f('Function {{buildReplace}} not supported'));
-  });
-};
-
 Informix.prototype.getCountForAffectedRows = function(model, info) {
   var affectedRows = info && typeof info.affectedRows === 'number' ?
       info.affectedRows : undefined;
@@ -847,6 +841,300 @@ function(model, rowData) {
     }
   }
   return data;
+};
+
+/**
+ * Update if the model instance exists with the same id or create a new instance
+ *
+ * @param {string} model The model name
+ * @param {Object} data The model instance data
+ * @param {Function} [callback] The callback function
+ */
+Informix.prototype.updateOrCreate = Informix.prototype.save =
+  function(model, data, options, callback) {
+    debug('Informix.prototype.updateOrCreate (enter): model=%j, data=%j, ' +
+          'options=%j ', model, data, options);
+    var self = this;
+    var idName = self.idName(model);
+    var stmt;
+    var tableName = self.tableEscaped(model);
+    var meta = {};
+
+    function executeWithConnection(connection, cb) {
+      // Execution for updateOrCreate requires running two
+      // separate SQL statements.  The second depends on the
+      // result of the first.
+      var where = {};
+      where[idName] = data[idName];
+
+      var countStmt = new ParameterizedSQL('SELECT COUNT(*) AS CNT FROM ');
+      countStmt.merge(tableName);
+      countStmt.merge(self.buildWhere(model, where));
+      countStmt.noResults = false;
+
+      connection.query(countStmt, function(err, countData) {
+        debug('Informix.prototype.updateOrCreate (data): err=%j, ' +
+        'countData=%j\n', err, countData);
+
+        if (err) return cb(err);
+
+        if (countData[0]['cnt'] > 0) {
+          stmt = self.buildUpdate(model, where, data);
+        } else {
+          stmt = self.buildInsert(model, data);
+        }
+
+        stmt.noResults = true;
+
+        connection.query(stmt, function(err, sData) {
+          debug('Informix.prototype.updateOrCreate (data): err=%j, sData=%j\n',
+                err, sData);
+
+          if (err) return cb(err);
+
+          meta.isNewInstance = countData[0]['cnt'] === 0;
+          cb(null, data, meta);
+        });
+      });
+    };
+
+    if (options.transaction) {
+      executeWithConnection(options.transaction.connection,
+        function(err, data, meta) {
+          if (err) {
+            return callback && callback(err);
+          } else {
+            return callback && callback(null, data, meta);
+          }
+        });
+    } else {
+      self.beginTransaction(Transaction.READ_COMMITTED, function(err, conn) {
+        if (err) {
+          conn.close(function() {});
+          return callback && callback(err);
+        }
+        executeWithConnection(conn, function(err, data, meta) {
+          if (err) {
+            conn.rollbackTransaction(function(err) {
+              conn.close(function() {});
+              return callback && callback(err);
+            });
+          } else {
+            options.transaction = undefined;
+            conn.commitTransaction(function(err) {
+              conn.close(function() {});
+
+              if (err) {
+                return callback && callback(err);
+              }
+
+              return callback && callback(null, data, meta);
+            });
+          }
+        });
+      });
+    }
+  };
+
+/**
+ * Replace if the model instance exists with the same id
+ * or create a new instance
+ *
+ * @param {string} model The model name
+ * @param {Object} data The model instance data
+ * @param {Function} [callback] The callback function
+ */
+Informix.prototype._replace = function(model, where, data, options, callback) {
+  debug('Informix.prototype._replace (enter): model=%j, data=%j, ' +
+        'options=%j\n', model, data, options);
+
+  var self = this;
+  var idName = self.idName(model);
+  var stmt;
+  var tableName = self.tableEscaped(model);
+  var meta = {};
+
+  function executeWithConnection(connection, cb) {
+    var stmt = new ParameterizedSQL('SELECT ' + idName + ' FROM ');
+    stmt.merge(tableName);
+    stmt.merge(self.buildWhere(model, where));
+    stmt.noResults = false;
+
+    connection.query(stmt, function(err, selectData) {
+      debug('Informix.prototype._replace stmt: %j data: %j err: %j\n',
+            stmt, selectData, err);
+      if (err) return cb(err);
+
+      if (selectData.length > 0) {
+        // remove existing to replace with a new insert
+        stmt = self.buildDelete(model, where, data);
+        stmt.noResults = true;
+        connection.query(stmt, function(err, res) {
+          debug('Informix.prototype._replace stmt: %j data: %j err=%j\n',
+                stmt, res, err);
+
+          if (err) return cb(err);
+
+          data[idName] = selectData[0][idName];
+          console.log('DATA: ', data);
+          stmt = self.buildInsert(model, data);
+
+          connection.query(stmt, function(err, insertData) {
+            debug('Informix.prototype._replace stmt: %j data:%j err: %j',
+                  stmt, insertData, err);
+            if (err) return cb(err);
+
+            meta.isNewInstance = selectData.length === 0;
+            return cb(null, selectData.length, meta);
+          });
+        });
+      } else {
+        return cb(errorIdNotFoundForReplace(where.id));
+      }
+    });
+  };
+
+  if (options.transaction) {
+    executeWithConnection(options.transaction.connection,
+      function(err, data, meta) {
+        if (err) {
+          return callback && callback(err);
+        } else {
+          return callback && callback(null, data, meta);
+        }
+      });
+  } else {
+    self.beginTransaction(Transaction.READ_COMMITTED, function(err, conn) {
+      if (err) {
+        return callback && callback(err);
+      }
+      executeWithConnection(conn, function(err, data, meta) {
+        if (err) {
+          conn.rollbackTransaction(function(err) {
+            conn.close(function() {});
+            return callback && callback(err);
+          });
+        } else {
+          options.transaction = undefined;
+          conn.commitTransaction(function(err) {
+            if (err) {
+              return callback && callback(err);
+            }
+
+            conn.close(function() {});
+            return callback && callback(null, data, meta);
+          });
+        }
+      });
+    });
+  }
+};
+
+/**
+ * Replace if the model instance exists with the same id
+ * or create a new instance
+ *
+ * @param {string} model The model name
+ * @param {Object} data The model instance data
+ * @param {Function} [callback] The callback function
+ */
+Informix.prototype.replaceOrCreate = function(model, data, options, callback) {
+  debug('Informix.prototype.replaceOrCreate (enter): model=%j, data=%j, ' +
+        'options=%j\n', model, data, options);
+  var self = this;
+  var idName = self.idName(model);
+  var stmt;
+  var tableName = self.tableEscaped(model);
+  var meta = {};
+
+  function executeWithConnection(connection, cb) {
+    // Execution for replaceOrCreate requires running 3
+    // separate SQL statements. The last depends on the
+    // result of the first couple.
+    var where = {};
+    where[idName] = data[idName];
+
+    var stmt = new ParameterizedSQL('SELECT ' + idName + ' FROM ');
+    stmt.merge(tableName);
+    stmt.merge(self.buildWhere(model, where));
+    stmt.noResults = false;
+
+    connection.query(stmt, function(err, selectData) {
+      debug('Informix.prototype.replaceOrCreate stmt: %j data: %j err: %j\n',
+            stmt, selectData, err);
+      if (err) return cb(err);
+
+      if (selectData.length > 0) {
+        // remove existing to replace with a new insert
+        stmt = self.buildDelete(model, where);
+        stmt.noResults = true;
+        connection.query(stmt, function(err, res) {
+          debug('Informix.prototype.replaceOrCreate stmt: %j data: %j err=%j\n',
+                stmt, res, err);
+
+          if (err) return cb(err);
+
+          data[idName] = selectData[0][idName];
+          stmt = self.buildInsert(model, data);
+
+          connection.query(stmt, function(err, insertData) {
+            if (err) return cb(err);
+
+            meta.isNewInstance = selectData.length === 0;
+            cb(null, data, meta);
+          });
+        });
+      } else {
+        stmt = self.buildInsert(model, data);
+        stmt.noResults = true;
+
+        connection.query(stmt, function(err, sData) {
+          debug('Informix.prototype.replaceOrCreate stmt: %j data: %j err=%j\n',
+                stmt, sData, err);
+
+          if (err) return cb(err);
+
+          meta.isNewInstance = selectData.length === 0;
+          cb(null, data, meta);
+        });
+      }
+    });
+  };
+
+  if (options.transaction) {
+    executeWithConnection(options.transaction.connection,
+      function(err, data, meta) {
+        if (err) {
+          return callback && callback(err);
+        } else {
+          return callback && callback(null, data, meta);
+        }
+      });
+  } else {
+    self.beginTransaction(Transaction.READ_COMMITTED, function(err, conn) {
+      if (err) {
+        return callback && callback(err);
+      }
+      executeWithConnection(conn, function(err, data, meta) {
+        if (err) {
+          conn.rollbackTransaction(function(err) {
+            conn.close(function() {});
+            return callback && callback(err);
+          });
+        } else {
+          options.transaction = undefined;
+          conn.commitTransaction(function(err) {
+            if (err) {
+              return callback && callback(err);
+            }
+
+            conn.close(function() {});
+            return callback && callback(null, data, meta);
+          });
+        }
+      });
+    });
+  }
 };
 
 require('./migration')(Informix);

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -127,10 +127,11 @@ module.exports = function(Informix) {
     var sql = 'SELECT COLNO, COLLENGTH AS DATALENGTH, COLTYPE AS DATATYPE, ' +
       'COLNAME AS NAME FROM SYSCOLUMNS INNER JOIN SYSTABLES ON ' +
       '(SYSCOLUMNS.TABID = SYSTABLES.TABID) WHERE ' +
-      'SYSTABLES.TABNAME LIKE \'' + self.table(model) + '\'' +
+      'SYSTABLES.TABNAME LIKE \'' + self.table(model).toLowerCase() + '\'' +
       'ORDER BY COLNO';
 
     self.execute(sql, function(err, tableInfo) {
+      debug('Informix.prototype.getTableStatus sql:%j data:%j', sql, tableInfo);
       if (err) {
         cb(err);
       } else {
@@ -140,8 +141,9 @@ module.exports = function(Informix) {
           'I.PART14, I.PART15, I.PART16 ' +
           'FROM SYSINDEXES I INNER JOIN SYSTABLES T ' +
           'ON (I.TABID = T.TABID) ' +
-          'WHERE T.TABNAME LIKE \'' + self.table(model) + '\'';
+          'WHERE T.TABNAME LIKE \'' + self.table(model).toLowerCase() + '\'';
         self.execute(indexSQL, function(err, indexInfo) {
+          debug('Informix.prototype.getTableStatus sql:%j data:%j', indexInfo);
           if (err) {
             cb(err);
           } else {


### PR DESCRIPTION
### Description
While the SQL statement in the loopback-ibmdb module is correct for informix, the resulting output data when run against DB2 will have a column name of CNT vs Informix which will return cnt due to Informix by default not allowing delimited table and column names.  To address this the function (unfortunately) has been copied and pasted into the Informix connector with the references to the count value using the correct case for Informix.

- [x ] New tests added or existing tests modified to cover all changes
- [x ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
